### PR TITLE
Fix für Textileaufruf

### DIFF
--- a/lib/TextileMigration/Replacer/SliceValueReplacer.php
+++ b/lib/TextileMigration/Replacer/SliceValueReplacer.php
@@ -151,8 +151,9 @@ class SliceValueReplacer
             case 'markdown':
                 break;
             case 'textile':
-                $textile = new \Textile();
-                $value = $textile->textileRestricted($value);
+                $parser = new Parser();
+                $parser = $parser->setRestricted(true);
+                $value  = $parser->parse($value);
                 break;
             default:
                 $parser = new Parser();


### PR DESCRIPTION
Aus der Funktion `textileRestricted` aus dem vendor```Parser::textileRestricted() is deprecated. Use Parser::parse() with Parser::setRestricted() instead.```

Behebt #2